### PR TITLE
feat: add.gitignore to exclude system files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+# Fichiers système
+.DS_Store
+Thumbs.db
+desktop.ini
 
+# Sécurité/Environnement
+.env
+*.key
+*.secret
+
+# Dépendances
+node_modules/
+dist/
+.temp/
+
+# Éditeurs
+.idea/
+.vscode/


### PR DESCRIPTION
- Ignore les fichiers systèmes (.DS_Store, Thumbs.db)  
- Protège les données sensibles (.env, *.key)  
- Exclut les dossiers inutiles (node_modules/, .cache/)  
- Compatible avec tous les OS (Mac/Windows/Linux)